### PR TITLE
Fix comment

### DIFF
--- a/kubernetes/secrets/powerapp-secrets.yaml
+++ b/kubernetes/secrets/powerapp-secrets.yaml
@@ -4,4 +4,4 @@ metadata:
   name: web
 type: Opaque
 data:
-  some-password: Q2lhbwo= # echo 'ciao' | base64
+  some-password: Q2lhbwo= # echo 'Ciao' | base64


### PR DESCRIPTION
Fix plain text source of encoded secret.

In alternative, remove new-line at the end of the password value (changing also the encoded value):
`  some-password: Q2lhbw== # echo -n 'Ciao' | base64`